### PR TITLE
doc: improve doc for newtype Builder

### DIFF
--- a/src/Data/Text/Builder/Linear.hs
+++ b/src/Data/Text/Builder/Linear.hs
@@ -37,7 +37,7 @@ import Data.Text.Builder.Linear.Buffer
 --
 -- Note that (similar to other builders) concatenation of 'Builder's allocates
 -- thunks. This is to a certain extent mitigated by aggressive inlining,
--- but it is faster to use 'Buffer' directly.
+-- and is faster than just using 'Buffer' directly.
 newtype Builder = Builder {unBuilder ∷ Buffer ⊸ Buffer}
 
 -- | Run 'Builder' computation on an empty 'Buffer', returning strict 'Text'.


### PR DESCRIPTION
>  but it is faster to use 'Buffer' directly.

The language feels ambiguous. I was left wondering -- what is faster, Builder or raw Buffer?

I've suggested an improvement. 