### PR TITLE
Add (#<|) and deprecate its alias (<|#)

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -144,7 +144,7 @@ prop4 acts = runBuffer f1 === runBuffer f2
   where
     addr# = "foo"#
     f1, f2 :: Buffer ⊸ Buffer
-    f1 = \b → addr# <|# interpretOnBuffer acts b
+    f1 = \b → addr# #<| interpretOnBuffer acts b
     f2 = \b → T.pack "foo" <| interpretOnBuffer acts b
 
 prop5 ∷ [Action] → Property


### PR DESCRIPTION
Previously the documentation stated that `(#<|)` was not supported by the parser. It turns out it is a silly interaction with `-XUnboxedTuples`. Adding extra spacing between the parentheses and the function fixes the issue.

This commit adds `(#<|)` and makes `(<|#)` its deprecated alias.