### PR TITLE
Add support for negative hexadecimal numbers

### DIFF
--- a/bench/BenchHexadecimal.hs
+++ b/bench/BenchHexadecimal.hs
@@ -21,42 +21,50 @@ import qualified Text.Builder
 word :: Word
 word = 123456789123456789
 
-benchLazyBuilder ∷ Int → T.Text
+benchLazyBuilder ∷ Word → T.Text
 benchLazyBuilder = toStrict . toLazyText . go mempty
   where
     go !acc 0 = acc
-    go !acc n = let i = fromIntegral n * word in go (hexadecimal i <> (acc <> hexadecimal i)) (n - 1)
+    go !acc n = let i = n * word in go (hexadecimal i <> (acc <> hexadecimal i)) (n - 1)
 
-benchLazyBuilderBS ∷ Int → B.ByteString
+benchLazyBuilderBS ∷ Word → B.ByteString
 benchLazyBuilderBS = B.toStrict . B.toLazyByteString . go mempty
   where
     go !acc 0 = acc
-    go !acc n = go (B.wordHex (fromIntegral n) <> (acc <> B.wordHex (fromIntegral n))) (n - 1)
+    go !acc n = go (B.wordHex n <> (acc <> B.wordHex n)) (n - 1)
 
 #ifdef MIN_VERSION_text_builder
-benchStrictBuilder ∷ Int → T.Text
+benchStrictBuilder ∷ Word → T.Text
 benchStrictBuilder = Text.Builder.run . go mempty
   where
     go !acc 0 = acc
-    go !acc n = let i = fromIntegral n * word in go (Text.Builder.hexadecimal i <> (acc <> Text.Builder.hexadecimal i)) (n - 1)
+    go !acc n = let i = n * word in go (Text.Builder.hexadecimal i <> (acc <> Text.Builder.hexadecimal i)) (n - 1)
 #endif
 
-benchLinearBuilder ∷ Int → T.Text
-benchLinearBuilder m = runBuffer (\b → go b m)
+benchLinearBuilderWord ∷ Word → T.Text
+benchLinearBuilderWord m = runBuffer (\b → go b m)
+  where
+    go ∷ Buffer ⊸ Word → Buffer
+    go !acc 0 = acc
+    go !acc n = let i = n * word in go (i &<| (acc |>& i)) (n - 1)
+
+benchLinearBuilderInt ∷ Word → T.Text
+benchLinearBuilderInt m = runBuffer (\b → go b (fromIntegral m))
   where
     go ∷ Buffer ⊸ Int → Buffer
     go !acc 0 = acc
-    go !acc n = let i = fromIntegral n * word in go (i &<| (acc |>& i)) (n - 1)
+    go !acc n = let i = n * fromIntegral word in go (i &<| (acc |>& i)) (n - 1)
 
 benchHexadecimal ∷ Benchmark
 benchHexadecimal = bgroup "Hexadecimal" $ map mkGroup [1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6]
 
-mkGroup :: Int → Benchmark
+mkGroup :: Word → Benchmark
 mkGroup n = bgroup (show n)
   [ bench "Data.Text.Lazy.Builder" $ nf benchLazyBuilder n
   , bench "Data.ByteString.Builder" $ nf benchLazyBuilderBS n
 #ifdef MIN_VERSION_text_builder
   , bench "Text.Builder" $ nf benchStrictBuilder n
 #endif
-  , bench "Data.Text.Builder.Linear" $ nf benchLinearBuilder n
+  , bench "Data.Text.Builder.Linear (Word)" $ nf benchLinearBuilderWord n
+  , bench "Data.Text.Builder.Linear (Int)" $ nf benchLinearBuilderInt n
   ]

--- a/src/Data/Text/Builder/Linear/Hex.hs
+++ b/src/Data/Text/Builder/Linear/Hex.hs
@@ -9,6 +9,8 @@ module Data.Text.Builder.Linear.Hex (
 
 import Data.Bits (Bits (..), FiniteBits (..))
 import Data.Text.Array qualified as A
+import Data.Int (Int8, Int16, Int32, Int64)
+import Data.Word (Word8, Word16, Word32, Word64)
 import GHC.Exts (Int (..), (>#))
 import GHC.ST (ST)
 
@@ -32,7 +34,15 @@ buffer |>& n =
     (finiteBitSize n `shiftR` 2)
     (\dst dstOff → unsafeAppendHex dst dstOff n)
     buffer
-{-# INLINEABLE (|>&) #-}
+{-# INLINEABLE[1] (|>&) #-}
+
+{-# RULES
+  "|>&/Int"   (|>&) = (\b n -> b |>& fromIntegral @Int   @Word   n);
+  "|>&/Int8"  (|>&) = (\b n -> b |>& fromIntegral @Int8  @Word8  n);
+  "|>&/Int16" (|>&) = (\b n -> b |>& fromIntegral @Int16 @Word16 n);
+  "|>&/Int32" (|>&) = (\b n -> b |>& fromIntegral @Int32 @Word32 n);
+  "|>&/Int64" (|>&) = (\b n -> b |>& fromIntegral @Int64 @Word64 n);
+  #-}
 
 -- | Prepend the lower-case hexadecimal representation of a number.
 --
@@ -53,7 +63,15 @@ n &<| buffer =
     (\dst dstOff → unsafePrependHex dst dstOff n)
     (\dst dstOff → unsafeAppendHex dst dstOff n)
     buffer
-{-# INLINEABLE (&<|) #-}
+{-# INLINEABLE[1] (&<|) #-}
+
+{-# RULES
+  "&<|/Int"   (&<|) = (\n b -> fromIntegral @Int   @Word   n &<| b);
+  "&<|/Int8"  (&<|) = (\n b -> fromIntegral @Int8  @Word8  n &<| b);
+  "&<|/Int16" (&<|) = (\n b -> fromIntegral @Int16 @Word16 n &<| b);
+  "&<|/Int32" (&<|) = (\n b -> fromIntegral @Int32 @Word32 n &<| b);
+  "&<|/Int64" (&<|) = (\n b -> fromIntegral @Int64 @Word64 n &<| b)
+  #-}
 
 unsafeAppendHex ∷ (Integral a, FiniteBits a) ⇒ A.MArray s → Int → a → ST s Int
 unsafeAppendHex marr !off 0 =


### PR DESCRIPTION
Current implementation segfaults on negative numbers. Fix this issue by supporting them.

Note: While I think the generic implementation works, I am not so confident about the rewrite rules & inlinable annotations.

May require some update to the doc in #10.