### PR TITLE
Add support for ASCII chars

### DIFF
--- a/bench/BenchAsciiChar.hs
+++ b/bench/BenchAsciiChar.hs
@@ -1,0 +1,237 @@
+-- |
+-- Copyright:   (c) 2022 Andrew Lelechenko
+-- Licence:     BSD3
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+
+module BenchAsciiChar (benchAsciiChar) where
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Builder as B
+import qualified Data.Text as T
+import Data.Text.Internal.Unsafe.Char (unsafeChr8)
+import Data.Text.Builder.Linear.Buffer
+import qualified Data.Text.Lazy as TL
+import Data.Text.Lazy (toStrict)
+import qualified Data.Text.Lazy.Builder as TB
+import Data.Text.Lazy.Builder (toLazyText, singleton)
+import qualified Data.Text.Internal.Fusion.Common as Fusion
+import qualified Data.Text.Internal.Fusion as Fusion
+import Data.Word (Word8)
+import Test.Tasty.Bench
+
+#ifdef MIN_VERSION_text_builder
+import qualified Text.Builder
+#endif
+
+#ifdef MIN_VERSION_bytestring_strict_builder
+import qualified ByteString.StrictBuilder
+#endif
+
+--------------------------------------------------------------------------------
+-- Single char
+--------------------------------------------------------------------------------
+
+benchLazyBuilder ∷ Word8 → T.Text
+benchLazyBuilder = toStrict . toLazyText . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = let ch = unsafeChr8 n in go (singleton ch <> (acc <> singleton ch)) (n - 1)
+
+benchLazyBuilderBS ∷ Word8 → B.ByteString
+benchLazyBuilderBS = B.toStrict . B.toLazyByteString . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = go (B.word8 n <> (acc <> B.word8 n)) (n - 1)
+
+#ifdef MIN_VERSION_text_builder
+benchStrictBuilder ∷ Word8 → T.Text
+benchStrictBuilder = Text.Builder.run . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = go (Text.Builder.utf8CodeUnits1 n <> (acc <> Text.Builder.utf8CodeUnits1 n)) (n - 1)
+#endif
+
+#ifdef MIN_VERSION_bytestring_strict_builder
+benchStrictBuilderBS ∷ Word8 → B.ByteString
+benchStrictBuilderBS = ByteString.StrictBuilder.builderBytes . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = go (ByteString.StrictBuilder.word8 n <> (acc <> ByteString.StrictBuilder.word8 n)) (n - 1)
+#endif
+
+benchLinearBuilder ∷ Word8 → T.Text
+benchLinearBuilder m = runBuffer (\b → go b m)
+  where
+    go ∷ Buffer ⊸ Word8 → Buffer
+    go !acc 0 = acc
+    go !acc n = go (n @<| (acc |>@ n)) (n - 1)
+
+benchSingleChar ∷ Benchmark
+benchSingleChar = bgroup "Single" $ map mkGroupChar [1e0, 1e1, 1e2]
+
+mkGroupChar :: Word8 → Benchmark
+mkGroupChar n = bgroup (show n)
+  [ bench "Data.Text.Lazy.Builder" $ nf benchLazyBuilder n
+  , bench "Data.ByteString.Builder" $ nf benchLazyBuilderBS n
+#ifdef MIN_VERSION_text_builder
+  , bench "Text.Builder" $ nf benchStrictBuilder n
+#endif
+#ifdef MIN_VERSION_bytestring_strict_builder
+  , bench "ByteString.StrictBuilder" $ nf benchStrictBuilderBS n
+#endif
+  , bench "Data.Text.Builder.Linear" $ nf benchLinearBuilder n
+  ]
+
+--------------------------------------------------------------------------------
+-- Multiple chars
+--------------------------------------------------------------------------------
+
+charCount :: Word
+charCount = 3
+
+benchCharsLazyBuilder ∷ Word8 → T.Text
+benchCharsLazyBuilder = TL.toStrict . TB.toLazyText . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = let ch = unsafeChr8 n in go (replicateChar ch <> (acc <> replicateChar ch)) (n - 1)
+
+    replicateChar ch = TB.fromText (Fusion.unstream (Fusion.replicateCharI charCount ch))
+
+benchCharsLazyBuilderBS ∷ Word8 → B.ByteString
+benchCharsLazyBuilderBS = B.toStrict . B.toLazyByteString . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = go (replicateChar n <> (acc <> replicateChar n)) (n - 1)
+
+    replicateChar ch = B.byteString (B.replicate (fromIntegral charCount) ch)
+
+{- [TODO]
+#ifdef MIN_VERSION_text_builder
+benchCharsStrictBuilder ∷ Word8 → T.Text
+benchCharsStrictBuilder = Text.Builder.run . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = let ch = chr n in go (replicateChar ch <> (acc <> replicateChar ch)) (n - 1)
+
+    -- [TODO] Is there a better way?
+    replicateChar ch = Text.Builder.padFromRight (fromIntegral charCount) ch mempty
+#endif
+
+#ifdef MIN_VERSION_bytestring_strict_builder
+benchCharsStrictBuilderBS ∷ Word8 → B.ByteString
+benchCharsStrictBuilderBS = ByteString.StrictBuilder.builderBytes . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = let ch = chr n in go _ (n - 1)
+#endif
+-}
+
+benchCharsLinearBuilder ∷ Word8 → T.Text
+benchCharsLinearBuilder m = runBuffer (\b → go b m)
+  where
+    go ∷ Buffer ⊸ Word8 → Buffer
+    go !acc 0 = acc
+    go !acc n = go (prependAsciiChars charCount n (appendAsciiChars charCount n acc)) (n - 1)
+
+benchMultipleChars ∷ Benchmark
+benchMultipleChars = bgroup "Multiple" $ map mkGroupChars [1e0, 1e1, 1e2]
+
+mkGroupChars :: Word8 → Benchmark
+mkGroupChars n = bgroup (show n)
+  [ bench "Data.Text.Lazy.Builder" $ nf benchCharsLazyBuilder n
+  , bench "Data.ByteString.Builder" $ nf benchCharsLazyBuilderBS n
+-- #ifdef MIN_VERSION_text_builder
+--   , bench "Text.Builder" $ nf benchCharsStrictBuilder n
+-- #endif
+-- #ifdef MIN_VERSION_bytestring_strict_builder
+--   , bench "ByteString.StrictBuilder" $ nf benchCharsStrictBuilderBS n
+-- #endif
+  , bench "Data.Text.Builder.Linear" $ nf benchCharsLinearBuilder n
+  ]
+
+--------------------------------------------------------------------------------
+-- Padding
+--------------------------------------------------------------------------------
+
+benchPaddingLazyBuilder ∷ Word8 → T.Text
+benchPaddingLazyBuilder = toStrict . toLazyText . go mempty 0
+  where
+    go !acc !_ 0 = acc
+    go !acc l  n =
+      let ch = unsafeChr8 n
+          !l' = l + 2 * fromIntegral charCount
+      in go (withText (T.justifyLeft l' ch)
+                      (withText (T.justifyRight (l + fromIntegral charCount) ch) acc))
+            l'
+            (n - 1)
+
+    withText f = TB.fromText . f . TL.toStrict . TB.toLazyText
+
+{- [TODO]
+benchPaddingLazyBuilderBS ∷ Word8 → B.ByteString
+benchPaddingLazyBuilderBS = B.toStrict . B.toLazyByteString . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = let ch = chr n in go _ (n - 1)
+-}
+
+#ifdef MIN_VERSION_text_builder
+benchPaddingStrictBuilder ∷ Word8 → T.Text
+benchPaddingStrictBuilder = Text.Builder.run . go mempty 0
+  where
+    go !acc !_ 0 = acc
+    go !acc l  n =
+      let ch = unsafeChr8 n
+          !l' = l + 2 * fromIntegral charCount
+      in go (Text.Builder.padFromRight l' ch (Text.Builder.padFromLeft (l + fromIntegral charCount) ch acc))
+            l'
+            (n - 1)
+#endif
+
+{- [TODO]
+#ifdef MIN_VERSION_bytestring_strict_builder
+benchPaddingStrictBuilderBS ∷ Word8 → B.ByteString
+benchPaddingStrictBuilderBS = ByteString.StrictBuilder.builderBytes . go mempty
+  where
+    go !acc 0 = acc
+    go !acc n = let ch = chr n in go _ (n - 1)
+#endif
+-}
+
+benchPaddingLinearBuilder ∷ Word8 → T.Text
+benchPaddingLinearBuilder m = runBuffer (\b → go b 0 m)
+  where
+    go ∷ Buffer ⊸ Word → Word8 → Buffer
+    go !acc !_ 0 = acc
+    go !acc l  n =
+      let !l' = l + 2 * charCount
+      in go (justifyLeftAscii l' n (justifyRightAscii (l + charCount) n acc))
+            l'
+            (n - 1)
+
+benchPadding ∷ Benchmark
+benchPadding = bgroup "Padding" $ map mkGroupPadding [1e0, 1e1, 1e2]
+
+mkGroupPadding :: Word8 → Benchmark
+mkGroupPadding n = bgroup (show n)
+  [ bench "Data.Text.Lazy.Builder" $ nf benchPaddingLazyBuilder n
+  -- , bench "Data.ByteString.Builder" $ nf benchPaddingLazyBuilderBS n
+#ifdef MIN_VERSION_text_builder
+  , bench "Text.Builder" $ nf benchPaddingStrictBuilder n
+#endif
+-- #ifdef MIN_VERSION_bytestring_strict_builder
+--   , bench "ByteString.StrictBuilder" $ nf benchPaddingStrictBuilderBS n
+-- #endif
+  , bench "Data.Text.Builder.Linear" $ nf benchPaddingLinearBuilder n
+  ]
+
+--------------------------------------------------------------------------------
+-- All benchmarks
+--------------------------------------------------------------------------------
+
+benchAsciiChar ∷ Benchmark
+benchAsciiChar = bgroup "ASCII Char"
+  [ benchSingleChar
+  , benchMultipleChars
+  , benchPadding ]
+

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -9,6 +9,7 @@ import Test.Tasty.Bench
 import Test.Tasty.Patterns.Printer
 
 import BenchChar
+import BenchAsciiChar
 import BenchDecimal
 import BenchDouble
 import BenchHexadecimal
@@ -17,6 +18,7 @@ import BenchText
 main ∷ IO ()
 main = defaultMain $ map (mapLeafBenchmarks addCompare) $
   [ benchText
+  , benchAsciiChar
   , benchChar
   , benchDecimal
   , benchHexadecimal

--- a/src/Data/Text/Builder/Linear/Buffer.hs
+++ b/src/Data/Text/Builder/Linear/Buffer.hs
@@ -20,12 +20,24 @@ module Data.Text.Builder.Linear.Buffer (
   (><),
 
   -- * Single character
+
+  -- ** ASCII
+  (|>@),
+  (@<|),
+
+  -- ** Unicode
   (|>.),
   (.<|),
 
   -- * Multiple characters
 
   -- ** Character replication
+
+  -- *** ASCII
+  prependAsciiChars,
+  appendAsciiChars,
+
+  -- *** Unicode
   prependChars,
   appendChars,
 
@@ -41,6 +53,13 @@ module Data.Text.Builder.Linear.Buffer (
   (<|#),
 
   -- * Padding
+
+  -- *** ASCII
+  justifyLeftAscii,
+  justifyRightAscii,
+  centerAscii,
+
+  -- *** Unicode
   justifyLeft,
   justifyRight,
   center,
@@ -66,6 +85,7 @@ import GHC.Exts (Addr#, Int (..), Ptr (..), cstringLength#, setByteArray#)
 import GHC.ST (ST (..))
 
 import Data.Text.Builder.Linear.Char
+import Data.Text.Builder.Linear.Char.ASCII
 import Data.Text.Builder.Linear.Core
 import Data.Text.Builder.Linear.Dec
 import Data.Text.Builder.Linear.Double

--- a/src/Data/Text/Builder/Linear/Char.hs
+++ b/src/Data/Text/Builder/Linear/Char.hs
@@ -37,6 +37,8 @@ import Data.Text.Builder.Linear.Core
 -- >>> runBuffer (\b -> b |>. 'q' |>. 'w')
 -- "qw"
 --
+-- Prefer '(|>@)' if the character is ASCII.
+--
 -- __Warning:__ In contrast to 'Data.Text.Lazy.Builder.singleton', it is the
 -- responsibility of the caller to sanitize surrogate code points with
 -- 'Data.Text.Internal.safe'.
@@ -50,6 +52,8 @@ buffer |>. ch = appendBounded 4 (\dst dstOff → unsafeWrite dst dstOff ch) buff
 -- >>> :set -XLinearTypes
 -- >>> runBuffer (\b -> 'q' .<| 'w' .<| b)
 -- "qw"
+--
+-- Prefer '(@<|)' if the character is ASCII.
 --
 -- __Warning:__ In contrast to 'Data.Text.Lazy.Builder.singleton', it is the
 -- responsibility of the caller to sanitize surrogate code points with

--- a/src/Data/Text/Builder/Linear/Char/ASCII.hs
+++ b/src/Data/Text/Builder/Linear/Char/ASCII.hs
@@ -13,6 +13,7 @@ module Data.Text.Builder.Linear.Char.ASCII (
   centerAscii,
 ) where
 
+import Data.Bits (Bits(..))
 import Data.Text.Builder.Linear.Array (unsafeReplicate)
 import Data.Text.Builder.Linear.Core
 import Data.Word (Word8)
@@ -36,7 +37,7 @@ prependAsciiChars count ch buff
   | otherwise =
       prependExact
         (fromIntegral count)
-        (\dst dstOff → unsafeReplicate dst dstOff (fromIntegral count) (fromIntegral ch))
+        (\dst dstOff → unsafeReplicate dst dstOff (fromIntegral count) (fromIntegral ch .&. 0x7f))
         buff
 
 -- | Append a given count of a ASCII 'Char' as 'Word8' to a 'Buffer'.
@@ -53,7 +54,7 @@ appendAsciiChars count ch buff
   | otherwise =
       appendExact
         (fromIntegral count)
-        (\dst dstOff → unsafeReplicate dst dstOff (fromIntegral count) (fromIntegral ch))
+        (\dst dstOff → unsafeReplicate dst dstOff (fromIntegral count) (fromIntegral ch .&. 0x7f))
         buff
 
 --------------------------------------------------------------------------------

--- a/src/Data/Text/Builder/Linear/Char/ASCII.hs
+++ b/src/Data/Text/Builder/Linear/Char/ASCII.hs
@@ -1,0 +1,118 @@
+-- |
+-- Copyright:   (c) 2023 Pierre Le Marre
+-- Licence:     BSD3
+-- Maintainer:  Andrew Lelechenko <andrew.lelechenko@gmail.com>
+module Data.Text.Builder.Linear.Char.ASCII (
+  -- * Multiple ASCI characters
+  prependAsciiChars,
+  appendAsciiChars,
+
+  -- * Padding
+  justifyLeftAscii,
+  justifyRightAscii,
+  centerAscii,
+) where
+
+import Data.Text.Builder.Linear.Array (unsafeReplicate)
+import Data.Text.Builder.Linear.Core
+import Data.Word (Word8)
+import Unsafe.Coerce (unsafeCoerce)
+
+--------------------------------------------------------------------------------
+-- Multiple chars
+--------------------------------------------------------------------------------
+
+-- | Prepend a given count of a ASCII 'Char' as 'Word8' to a 'Buffer'.
+--
+-- >>> :set -XLinearTypes
+-- >>> runBuffer (\b -> prependAsciiChars 3 120 (b |>@ 65))
+-- "xxxA"
+--
+-- __Warning:__ In contrast to 'Data.Text.Lazy.Builder.singleton', it is the
+-- responsibility of the caller to ensure that the 'Word8' is a valid ASCII character.
+prependAsciiChars ∷ Word → Word8 → Buffer ⊸ Buffer
+prependAsciiChars count ch buff
+  | count == 0 = buff
+  | otherwise =
+      prependExact
+        (fromIntegral count)
+        (\dst dstOff → unsafeReplicate dst dstOff (fromIntegral count) (fromIntegral ch))
+        buff
+
+-- | Append a given count of a ASCII 'Char' as 'Word8' to a 'Buffer'.
+--
+-- >>> :set -XLinearTypes
+-- >>> runBuffer (\b -> appendAsciiChars 3 120 (b |>@ 65))
+-- "Axxx"
+--
+-- __Warning:__ In contrast to 'Data.Text.Lazy.Builder.singleton', it is the
+-- responsibility of the caller to ensure that the 'Word8' is a valid ASCII character.
+appendAsciiChars ∷ Word → Word8 → Buffer ⊸ Buffer
+appendAsciiChars count ch buff
+  | count == 0 = buff
+  | otherwise =
+      appendExact
+        (fromIntegral count)
+        (\dst dstOff → unsafeReplicate dst dstOff (fromIntegral count) (fromIntegral ch))
+        buff
+
+--------------------------------------------------------------------------------
+-- Padding
+--------------------------------------------------------------------------------
+
+-- | Pad a builder from the /left/ side to the specified length with the specified
+-- ASCII character.
+--
+-- >>> :set -XLinearTypes
+-- >>> runBuffer (\b -> justifyRightAscii 10 120 (appendAsciiChars 3 65 b))
+-- "xxxxxxxAAA"
+-- >>> runBuffer (\b -> justifyRightAscii 5 120 (appendAsciiChars 6 65 b))
+-- "AAAAAA"
+justifyRightAscii ∷ Word → Word8 → Buffer ⊸ Buffer
+justifyRightAscii n ch buff = case lengthOfBuffer buff of
+  (# buff', len #) →
+    toLinearWord
+      (\l b → if n <= l then b else prependAsciiChars (n - l) ch b)
+      len
+      buff'
+
+-- | Pad a builder from the /right/ side to the specified length with the specified
+-- ASCII character.
+--
+-- >>> :set -XLinearTypes
+-- >>> runBuffer (\b -> justifyLeftAscii 10 120 (appendAsciiChars 3 65 b))
+-- "AAAxxxxxxx"
+-- >>> runBuffer (\b -> justifyLeftAscii 5 120 (appendAsciiChars 6 65 b))
+-- "AAAAAA"
+justifyLeftAscii ∷ Word → Word8 → Buffer ⊸ Buffer
+justifyLeftAscii n ch buff = case lengthOfBuffer buff of
+  (# buff', len #) →
+    toLinearWord
+      (\l b → if n <= l then b else appendAsciiChars (n - l) ch b)
+      len
+      buff'
+
+-- | Center a builder to the specified length with the specified ASCII character.
+--
+-- >>> :set -XLinearTypes
+-- >>> runBuffer (\b -> centerAscii 10 120 (appendAsciiChars 3 65 b))
+-- "xxxxAAAxxx"
+-- >>> runBuffer (\b -> centerAscii 5 120 (appendAsciiChars 6 65 b))
+-- "AAAAAA"
+centerAscii ∷ Word → Word8 → Buffer ⊸ Buffer
+centerAscii n ch buff = case lengthOfBuffer buff of
+  (# buff', len #) →
+    toLinearWord
+      ( \l b →
+          if n <= l
+            then b
+            else case n - l of
+              !d → case d `quot` 2 of
+                !r → appendAsciiChars r ch (prependAsciiChars (d - r) ch b)
+      )
+      len
+      buff'
+
+-- Despite the use of unsafeCoerce, this is safe.
+toLinearWord ∷ (Word → a) → (Word ⊸ a)
+toLinearWord = unsafeCoerce

--- a/text-builder-linear.cabal
+++ b/text-builder-linear.cabal
@@ -32,6 +32,7 @@ library
     other-modules:
         Data.Text.Builder.Linear.Array
         Data.Text.Builder.Linear.Char
+        Data.Text.Builder.Linear.Char.ASCII
         Data.Text.Builder.Linear.Dec
         Data.Text.Builder.Linear.Double
         Data.Text.Builder.Linear.Hex
@@ -72,6 +73,7 @@ benchmark linear-builder-bench
     main-is:            Main.hs
     hs-source-dirs:     bench
     other-modules:
+        BenchAsciiChar
         BenchChar
         BenchDecimal
         BenchDouble


### PR DESCRIPTION
ASCII characters are encoded as a single byte in UTF-8, so there is an opportunity to optimize the interface for them.

__NOTE:__ names subject to bikeshedding.

- Add `(|>@)` and `(@<|)` to concatenate single ASCII characters.
- Add `prependAsciiChars` and `appendAsciiChars` for multiple characters.
- Add `justifyLeftAscii`, `justifyRightAscii` and `centerAscii` for padding.
- Move low-level `MArray` manipulation to their own module `Data.Text.Builder.Linear.Array`.
- Add corresponding tests & benchmarks.

See also #14, which propose a similar interface for padding.

Note that it adds a dependency on `linear-base` to use `move` and `Ur`.